### PR TITLE
fix: replace default theme meta description with site description

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -52,7 +52,7 @@ target = "assets/css/bootstrap-print.css"
 
 [params]
 title = 'Raulitoflying'
-description = 'This hugo theme (Adritian) is based on Bootstrap and has features that make it suitable for a personal site, a portfolio or other kind of Single Page Applications.'
+description = 'Yixiang Zhou — Software & Data Engineer specializing in NLP, LLM-based classification, and full-stack development. Portfolio of projects, experience, and publications.'
 images = ['/img/og-img.png']
 sections = [
   "showcase",

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -2,7 +2,7 @@
 - id: "meta_title"
   translation: "Adritian - a high performance hugo theme by Adrián Moreno"
 - id: "meta_description"
-  translation: "This hugo theme (Adritian) is based on Bootstrap and has features that make it suitable for a personal site, a portfolio or other kind of Single Page Applications."
+  translation: "Yixiang Zhou — Software & Data Engineer specializing in NLP, LLM-based classification, and full-stack development."
 - id: "meta_keywords"
   translation: "hugo, theme, bootstrap, adritian, adrian moreno, personal site, portfolio, single page application"
 - id: "meta_author"
@@ -50,7 +50,7 @@
   translation: "Personal Site for Yixiang Zhou - a high performance hugo page"
 
 - id: "head_description"
-  translation: "This hugo theme is based on Bootstrap and has features that make it suitable for a personal site, a portfolio or other kind of Single Page Applications."
+  translation: "Yixiang Zhou — Software & Data Engineer specializing in NLP, LLM-based classification, and full-stack development."
 
 
 ## Blog


### PR DESCRIPTION
## Fix: Replace default theme meta description

Your site is currently using the Adritian theme's default meta description, which appears in search engine results and social media previews as:

> "This hugo theme (Adritian) is based on Bootstrap and has features that make it suitable for a personal site, a portfolio or other kind of Single Page Applications."

This happens due to [zetxek/adritian-free-hugo-theme#560](https://github.com/zetxek/adritian-free-hugo-theme/issues/560) — a bug where the theme's fallback chain skips `params.description`. The fix is in PR #561, but in the meantime this PR sets your own description.

### Changes
- Set `description` in hugo.toml
- Updated `i18n/en.yaml` head_description and meta_description

> 🤖 This PR was prepared by @zetxek using an AI coding agent. Happy to adjust if the description doesn't feel right!
